### PR TITLE
Fix component name normalization

### DIFF
--- a/src/createBlueKit.js
+++ b/src/createBlueKit.js
@@ -70,7 +70,7 @@ function generateComponentData(config, file, directory) {
       .trim();
 
 
-    const name = menu.replace(/\s/g, '');
+    const name = menu.replace(/\W/g, '');
 
     const importFile = normalizePath(getImportFile(directory, file));
     const componentName = normalizedFile.replace(/.*\//, '').split('.')[0];


### PR DESCRIPTION
Problem:
We name our components like `HamburgerMenu.react.viewer.js` which resulted in invalid `import`s in `componentsIndex.js`. Notice the dot in this import:   
```
import ComponentsLayoutHamburgerMenu.viewer from './components/layout/HamburgerMenu.react.viewer.js';
```

Solution:
Remove all "non-character" (regexp `\W`) chars from component names.