### PR TITLE
Add component jsdoc description to sidebar

### DIFF
--- a/example_components/Checkbox.react.js
+++ b/example_components/Checkbox.react.js
@@ -4,8 +4,17 @@ import Radium from 'radium';
 import React from 'react';
 import ToolTip from '../src/app/atoms/ToolTip.react';
 
+
+/**
+ * A simple checkbox element
+ */
 @Radium
 export default class Checkbox extends Component {
+  /**
+   * @param {String} [error] - An error string
+   * @param {String} label - Checkbox label
+   * @param {String} name - The name of the checkbox component
+   */
 
   static propTypes = {
     error:    React.PropTypes.string,

--- a/src/app/component/PropsSidebar.react.js
+++ b/src/app/component/PropsSidebar.react.js
@@ -64,6 +64,7 @@ export default class PropsSidebar extends Component {
               visible={dropdownOpened}
             />
           </div>
+          <p style={styles.description}>{atom.get('description')}</p>
           <div style={styles.clearfix}>
             <h3
               style={[
@@ -299,6 +300,13 @@ const styles = {
     padding: `0 ${spaces.normal}`,
     width: '75%',
     wordBreak: 'break-all'
+  },
+
+  description: {
+    ...font,
+    ...font.size.small,
+    color: colors.BLACK_BRIGHT,
+    padding: `0 ${spaces.normal}`,
   },
 
   bgWrapper: {


### PR DESCRIPTION
If add docs to your component it can be imported and used as a description under the component name.

Added an example documentation to the example_components checkbox.