### PR TITLE
Make component source string replacements optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ createBlueKit({
   // your directory where components are located
   baseDir: `${__dirname}/src/browser`,
   // relative paths from base dir where to look for components
-  paths: ['./components/', './auth']
+  paths: ['./components/', './auth'],
+  // set to false to disable specialized component code mutations the bluekit team uses
+  specialReplacements: false
 });
 ```
 

--- a/src/createBlueKit.js
+++ b/src/createBlueKit.js
@@ -47,12 +47,13 @@ function getImportFile(directory, file) {
 
 function generateComponentData(config, file, directory) {
   const filePath = path.join(directory, file);
-  const content = fs.readFileSync(filePath)
-    .toString()
-    .replace('_interopRequireDefault(_react)', 'require("react")')
-    .replace(/import Component from ["']react-pure-render\/component["']/, 'import {Component} from "react"')
-    .replace(/export default .*\((\w*)\)+/m, 'export default $1')
-
+  let content = fs.readFileSync(filePath).toString()
+  if (config.specialReplacements) {
+    content = content
+      .replace('_interopRequireDefault(_react)', 'require("react")')
+      .replace(/import Component from ["']react-pure-render\/component["']/, 'import {Component} from "react"')
+      .replace(/export default .*\((\w*)\)+/m, 'export default $1')
+  }
   try {
     const docgen = docgenParse(content);
     const doc = {


### PR DESCRIPTION
As the string replacements were causing invalid source when given a pure component such as

```
export default function MyComponent() {
  return <div>Hello</div>
}
```

and turning them off seems to work just fine, provide an option to do so.