### PR TITLE
Default selectedAtom prop to null if it isn't a valid name

### DIFF
--- a/src/app/Page.react.js
+++ b/src/app/Page.react.js
@@ -59,9 +59,11 @@ export default class Page extends Component {
   render() {
     const {
       children, componentsIndex, customProps, simplePropsSelected, filteredComponentsIndex, sourceBackground,
-      height, inline, selectedAtom, showMobileSidebar, showMobileProps, searchedText, triggeredProps
+      height, inline, showMobileSidebar, showMobileProps, searchedText, triggeredProps
     } = this.props
+    let {selectedAtom} = this.props;
     const {selectAtom, searchAtoms, toggleMobileProps, toggleSidebar} = this.context
+    selectedAtom = componentsIndex.get(selectedAtom) ? selectedAtom : null;
     const allComponentsPreview = selectedAtom === null
 
     return (


### PR DESCRIPTION
Look up `selectedAtom` in `componentsIndex` Map and, if it doesn't exist, default `selectedAtom` to `null`.

Fixes #82.