### PR TITLE
CircleCI fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,11 @@ jobs:
       - restore_cache:
           key: example-cache-{{ checksum "example/package.json" }}
       - run:
-          command: npm install -g gulp
+          command: npm run gulp -- ava
       - run:
-          command: gulp ava
+          command: npm run gulp -- eslint
       - run:
-          command: gulp eslint
-      - run:
-          command: cd example && gulp
+          command: cd example && npm run gulp -- default
       - run:
           command: sleep 10 && curl --retry 10 --retry-delay 5 -v http://localhost:3000/
 

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "description": "Boilerplate for ReactJS project with hot code reloading",
   "scripts": {
     "start": "node server.js",
+    "gulp": "gulp $1",
     "lint": "eslint src"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:lib": "babel src --out-dir lib",
     "check": "npm run lint && npm run test",
     "clean": "rimraf lib",
+    "gulp": "gulp $1",
     "lint": "eslint src test examples",
     "postversion": "git push && git push --tags && npm run clean",
     "prepublish": "npm run clean && npm run build",


### PR DESCRIPTION
Instead of using a global install of gulp, we can use the local install.

We can use `npx gulp` with the latest npm version or, as in this PR, add a script gulp that we will call as `npm run gulp -- default`, forcing npm to use the local version.

